### PR TITLE
Allow for reading/writing object meta data - Implements #24

### DIFF
--- a/Example/AmazonS3RequestManager.xcodeproj/project.pbxproj
+++ b/Example/AmazonS3RequestManager.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		92E8C4391C4EFD4800759119 /* AmazonS3RequestSerializerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92E8C3EB1C4EF62400759119 /* AmazonS3RequestSerializerTests.swift */; };
 		92E8C43A1C4EFD4A00759119 /* AmazonS3ResponseSerializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92E8C3EC1C4EF62400759119 /* AmazonS3ResponseSerializationTests.swift */; };
 		CC41F8986EEDCF29E9B5CB4D /* Pods_OSX_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F0914547996879F9181CB5CD /* Pods_OSX_Tests.framework */; };
+		F3229E3F1C9D28D600848C84 /* AmazonS3ResponseObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3229E3E1C9D28D500848C84 /* AmazonS3ResponseObjectTests.swift */; };
+		F3229E401C9D28D600848C84 /* AmazonS3ResponseObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3229E3E1C9D28D500848C84 /* AmazonS3ResponseObjectTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -79,7 +81,7 @@
 		92E8C3E91C4EF62400759119 /* AmazonS3ACLTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AmazonS3ACLTests.swift; sourceTree = "<group>"; };
 		92E8C3EA1C4EF62400759119 /* AmazonS3RequestManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AmazonS3RequestManagerTests.swift; sourceTree = "<group>"; };
 		92E8C3EB1C4EF62400759119 /* AmazonS3RequestSerializerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AmazonS3RequestSerializerTests.swift; sourceTree = "<group>"; };
-		92E8C3EC1C4EF62400759119 /* AmazonS3ResponseSerializationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AmazonS3ResponseSerializationTests.swift; sourceTree = "<group>"; };
+		92E8C3EC1C4EF62400759119 /* AmazonS3ResponseSerializationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = AmazonS3ResponseSerializationTests.swift; sourceTree = "<group>"; };
 		92E8C40B1C4EFAC800759119 /* OSX-Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "OSX-Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		92E8C40D1C4EFAC900759119 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		92E8C40F1C4EFAC900759119 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -94,6 +96,7 @@
 		E8014EE70C8CB23D8CC5CB28 /* Pods-OSX-Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OSX-Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-OSX-Tests/Pods-OSX-Tests.release.xcconfig"; sourceTree = "<group>"; };
 		EB60E86E5E26A196521F36DB /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F0914547996879F9181CB5CD /* Pods_OSX_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OSX_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F3229E3E1C9D28D500848C84 /* AmazonS3ResponseObjectTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AmazonS3ResponseObjectTests.swift; sourceTree = "<group>"; };
 		F63C1F90FFF008F3C3588032 /* Pods-iOS-Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Example/Pods-iOS-Example.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -202,6 +205,7 @@
 				92E8C3EC1C4EF62400759119 /* AmazonS3ResponseSerializationTests.swift */,
 				607FACE91AFB9204008FA782 /* Supporting Files */,
 				92E8C3E81C4EF62300759119 /* AmazonS3RequestManager_Tests-Bridging-Header.h */,
+				F3229E3E1C9D28D500848C84 /* AmazonS3ResponseObjectTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -624,6 +628,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				92E8C3EF1C4EF62400759119 /* AmazonS3RequestSerializerTests.swift in Sources */,
+				F3229E3F1C9D28D600848C84 /* AmazonS3ResponseObjectTests.swift in Sources */,
 				92E8C3ED1C4EF62400759119 /* AmazonS3ACLTests.swift in Sources */,
 				92E8C3EE1C4EF62400759119 /* AmazonS3RequestManagerTests.swift in Sources */,
 				92E8C3F01C4EF62400759119 /* AmazonS3ResponseSerializationTests.swift in Sources */,
@@ -644,6 +649,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				92E8C43A1C4EFD4A00759119 /* AmazonS3ResponseSerializationTests.swift in Sources */,
+				F3229E401C9D28D600848C84 /* AmazonS3ResponseObjectTests.swift in Sources */,
 				92E8C4371C4EFD4400759119 /* AmazonS3ACLTests.swift in Sources */,
 				92E8C4391C4EFD4800759119 /* AmazonS3RequestSerializerTests.swift in Sources */,
 				92E8C4381C4EFD4600759119 /* AmazonS3RequestManagerTests.swift in Sources */,

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -407,6 +407,10 @@
 		F17EB2307CA64C2B1665977C /* NSURLRequest+DSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 0891CAF6FA487888398CE7E7 /* NSURLRequest+DSL.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		F23800823BC079F4631EC28B /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BA74C7BA89AB9CCF1D015371 /* Cocoa.framework */; };
 		F29A0A1E8768E3CE7D104778 /* LSHTTPResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = E3AC438C30732EE478243CF1 /* LSHTTPResponse.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		F3229E3A1C9B438A00848C84 /* AmazonS3ResponseObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3229E381C9B434500848C84 /* AmazonS3ResponseObjects.swift */; };
+		F3229E3B1C9B438B00848C84 /* AmazonS3ResponseObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3229E381C9B434500848C84 /* AmazonS3ResponseObjects.swift */; };
+		F3229E3C1C9B438C00848C84 /* AmazonS3ResponseObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3229E381C9B434500848C84 /* AmazonS3ResponseObjects.swift */; };
+		F3229E3D1C9B438D00848C84 /* AmazonS3ResponseObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3229E381C9B434500848C84 /* AmazonS3ResponseObjects.swift */; };
 		F350548CDCEC3A3C366C3897 /* Match.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51243367FEF7EB0471E10CC8 /* Match.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		F4E81C5F1E5139896AA106F3 /* DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6BFC4E1B9807A1305E16C04 /* DSL.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		F58D4ECFA6272A232CF99399 /* SWXMLHash.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCEF06EA08C339B950798325 /* SWXMLHash.framework */; };
@@ -747,7 +751,7 @@
 		6EA168ECAF7A0FB3C6D562D4 /* SuiteHooks.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SuiteHooks.swift; path = Quick/Hooks/SuiteHooks.swift; sourceTree = "<group>"; };
 		6F7258A6A644DDC63C816E31 /* Functional.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Functional.swift; path = Nimble/Utils/Functional.swift; sourceTree = "<group>"; };
 		6FBF5AD14A82BC160D5DD78E /* LSHTTPRequestDiff.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LSHTTPRequestDiff.h; path = Nocilla/Diff/LSHTTPRequestDiff.h; sourceTree = "<group>"; };
-		719692942D31DDE22E5EA985 /* AmazonS3ResponseSerialization.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AmazonS3ResponseSerialization.swift; sourceTree = "<group>"; };
+		719692942D31DDE22E5EA985 /* AmazonS3ResponseSerialization.swift */ = {isa = PBXFileReference; includeInIndex = 1; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = AmazonS3ResponseSerialization.swift; sourceTree = "<group>"; };
 		72B3FB455DAE52F3EAD2927D /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = "../Pods-iOS-Tests-Quick/Info.plist"; sourceTree = "<group>"; };
 		730DA671CA25DBD8FF0FCD23 /* Error.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Error.swift; path = Source/Error.swift; sourceTree = "<group>"; };
 		73190DC40A5B3D7A64E6AD4E /* Pods-OSX-Example-SWXMLHash-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-OSX-Example-SWXMLHash-prefix.pch"; sourceTree = "<group>"; };
@@ -927,6 +931,7 @@
 		F209D75630A61F8D0EA6A34B /* Pods-OSX-Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-OSX-Example-umbrella.h"; sourceTree = "<group>"; };
 		F25D1B6D8BDB2CD0F9F27596 /* Pods-OSX-Tests-Nimble.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-OSX-Tests-Nimble.modulemap"; sourceTree = "<group>"; };
 		F28CD9F77E8AA7CBBAA733C6 /* Pods-OSX-Example-AmazonS3RequestManager.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-OSX-Example-AmazonS3RequestManager.xcconfig"; sourceTree = "<group>"; };
+		F3229E381C9B434500848C84 /* AmazonS3ResponseObjects.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AmazonS3ResponseObjects.swift; sourceTree = "<group>"; };
 		F34B5A25AE26FCDCB2A161FF /* Pods-iOS-Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-iOS-Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		F48F75F918FB529909ACA881 /* Alamofire.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Alamofire.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F66A7D5F60CD28C292AF323C /* ExampleMetadata.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleMetadata.swift; path = Quick/ExampleMetadata.swift; sourceTree = "<group>"; };
@@ -1360,6 +1365,7 @@
 				AAA33FE14C4146542A09639C /* AmazonS3RequestManager.swift */,
 				FE46E0B80120B667241C72C0 /* AmazonS3RequestSerializer.swift */,
 				719692942D31DDE22E5EA985 /* AmazonS3ResponseSerialization.swift */,
+				F3229E381C9B434500848C84 /* AmazonS3ResponseObjects.swift */,
 				307FAFEFC1BAE83F90E827E8 /* AmazonS3SignatureHelpers.h */,
 				1A9B9E214EDCEF2B0CFE4658 /* AmazonS3SignatureHelpers.m */,
 			);
@@ -2344,7 +2350,7 @@
 		824287F7107F0B1A75BA2BC0 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0700;
+				LastSwiftUpdateCheck = 0720;
 				LastUpgradeCheck = 0700;
 			};
 			buildConfigurationList = 8DBBE147C4AD334B2CF563AC /* Build configuration list for PBXProject "Pods" */;
@@ -2403,6 +2409,7 @@
 				EB4C59A4AF6E242243A92B5E /* AmazonS3RequestManager.swift in Sources */,
 				18B6A114E73D4045D48F30CE /* AmazonS3RequestSerializer.swift in Sources */,
 				0680D284C27DC5C054EF0B1F /* AmazonS3ResponseSerialization.swift in Sources */,
+				F3229E3C1C9B438C00848C84 /* AmazonS3ResponseObjects.swift in Sources */,
 				7F3258E65DDD3A28EE42971B /* AmazonS3SignatureHelpers.m in Sources */,
 				3E9E477179AE0DCCDA113E25 /* Pods-OSX-Example-AmazonS3RequestManager-dummy.m in Sources */,
 			);
@@ -2527,6 +2534,7 @@
 				7C4A18638E3ADFC319C7A29D /* AmazonS3RequestManager.swift in Sources */,
 				10CFA1B616D57B424C958D6A /* AmazonS3RequestSerializer.swift in Sources */,
 				EEF9E7166EC3AA066A970E10 /* AmazonS3ResponseSerialization.swift in Sources */,
+				F3229E3B1C9B438B00848C84 /* AmazonS3ResponseObjects.swift in Sources */,
 				7BFE0C8C1B290869BE4951D5 /* AmazonS3SignatureHelpers.m in Sources */,
 				820AA138F03F097E60FC2181 /* Pods-iOS-Tests-AmazonS3RequestManager-dummy.m in Sources */,
 			);
@@ -2602,6 +2610,7 @@
 				956E5F2F2399777A9080DAF5 /* AmazonS3RequestManager.swift in Sources */,
 				6C28675F20ED8494D687CA1B /* AmazonS3RequestSerializer.swift in Sources */,
 				308FFFD9635FED8C155984AD /* AmazonS3ResponseSerialization.swift in Sources */,
+				F3229E3A1C9B438A00848C84 /* AmazonS3ResponseObjects.swift in Sources */,
 				EDAF0119175EA194899C626D /* AmazonS3SignatureHelpers.m in Sources */,
 				0B4ACCBBCE752E3A0400F4DA /* Pods-iOS-Example-AmazonS3RequestManager-dummy.m in Sources */,
 			);
@@ -2722,6 +2731,7 @@
 				D59D471E3FA361CAD04A9AF1 /* AmazonS3RequestManager.swift in Sources */,
 				28E04214F7F8DB79C4E7E4EC /* AmazonS3RequestSerializer.swift in Sources */,
 				E3906C8CDB1205796C78BA3E /* AmazonS3ResponseSerialization.swift in Sources */,
+				F3229E3D1C9B438D00848C84 /* AmazonS3ResponseObjects.swift in Sources */,
 				E504204E8A883EDB9290FC28 /* AmazonS3SignatureHelpers.m in Sources */,
 				E152D6AD1C517E84ED3E54B8 /* Pods-OSX-Tests-AmazonS3RequestManager-dummy.m in Sources */,
 			);
@@ -3789,6 +3799,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 1D75A653685F91A63F54ECC6 /* Pods-iOS-Example.debug.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -3879,6 +3890,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9556084FE4CB386143481A2B /* Pods-iOS-Example.release.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;

--- a/Example/Tests/AmazonS3RequestManagerTests.swift
+++ b/Example/Tests/AmazonS3RequestManagerTests.swift
@@ -228,6 +228,21 @@ class AmazonS3RequestManagerTests: XCTestCase {
     // then
     XCTAssertEqual(request.request!.URL!, expectedURL)
   }
+    
+  /*
+  *  MARK: - HEAD Object Request - Tests
+  */
+    
+  func test__headObject_setsHTTPMethod() {
+    // given
+    let expected = "HEAD"
+    
+    // when
+    let request = sut.headObject("test")
+    
+    // then
+    XCTAssertEqual(request.request!.HTTPMethod!, expected)
+  }
   
   /*
   *  MARK: - ACL Request - Tests

--- a/Example/Tests/AmazonS3RequestSerializerTests.swift
+++ b/Example/Tests/AmazonS3RequestSerializerTests.swift
@@ -211,5 +211,18 @@ class AmazonS3RequestSerializerTests: XCTestCase {
     // then
     XCTAssertNotNil(aclHeader, "Should have ACL header field")
   }
+    
+  func test__amazonURLRequest__givenMetaData__setsHTTPHeader_amz_meta() {
+    // given
+    let metaData = ["demo" : "foo"]
+    let request = sut.amazonURLRequest(.HEAD, path: "test", acl: nil, metaData: metaData)
+    
+    // when
+    let headers = request.allHTTPHeaderFields!
+    let metaDataHeader: String? = headers["x-amz-meta-demo"]
+    
+    // then
+    XCTAssertEqual(metaDataHeader, "foo", "Meta data header field is not set correctly.")
+  }
   
 }

--- a/Example/Tests/AmazonS3ResponseObjectTests.swift
+++ b/Example/Tests/AmazonS3ResponseObjectTests.swift
@@ -1,0 +1,77 @@
+//
+//  AmazonS3ResponseObjectTests.swift
+//  AmazonS3RequestManager
+//
+//  Created by Sebastian Hunkeler on 19/03/16.
+//  Copyright © 2016 CocoaPods. All rights reserved.
+//
+
+import XCTest
+import Nimble
+import Alamofire
+
+@testable import AmazonS3RequestManager
+
+class AmazonS3ResponseObjectTests: XCTestCase {
+
+    func test__responseS3Object_givenXMLString_returnsS3ListBucketResult() {
+        // given
+        let dateFormatter = NSDateFormatter()
+        dateFormatter.timeZone = NSTimeZone.localTimeZone()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSSZ"
+        let expectedModifiedDate = dateFormatter.dateFromString("2016-03-03 14:54:27.000Z")
+        
+        let xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+            "<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">" +
+            "<IsTruncated>true</IsTruncated>" +
+            "<MaxKeys>3</MaxKeys>" +
+            "<Delimiter />" +
+            "<Marker />" +
+            "<Prefix />" +
+            "<Name>TESTBUCKET1</Name>" +
+            "<Contents>" +
+            "<Key>demo.txt</Key>" +
+            "<LastModified>2016-03-03T14:54:27.000Z</LastModified>" +
+            "<ETag>\"2016-03-03 14:54:27.043:75b650fa317e55090741576852a79562\"</ETag>" +
+            "<Size>6</Size>" +
+            "<StorageClass>STANDARD</StorageClass>" +
+            "<Owner>" +
+            "<ID>61646d696e00000000</ID>" +
+            "<DisplayName>admin</DisplayName>" +
+            "</Owner>" +
+            "</Contents>" +
+            "<Contents>" +
+            "<Key>test.rtf</Key>" +
+            "<LastModified>2016-02-23T15:38:06.000Z</LastModified>" +
+            "<ETag>\"2016-02-23 15:38:06.741:01250c473283ed48e8429338500a97e1\"</ETag>" +
+            "<Size>178</Size>" +
+            "<StorageClass>STANDARD</StorageClass>" +
+            "<Owner>" +
+            "<ID>61646d696e000000000</ID>" +
+            "<DisplayName>admin</DisplayName>" +
+            "</Owner>" +
+            "</Contents>" +
+        "</ListBucketResult>"
+        let data = xml.dataUsingEncoding(NSUTF8StringEncoding)
+        
+        // when
+        let result = Request.XMLResponseSerializer().serializeResponse(nil, nil, data, nil)
+        let xmlIndexer = result.value!
+        let bucketContents = S3ListBucketResult(response:NSHTTPURLResponse(), representation:xmlIndexer)!
+        let s3File = bucketContents.files.first!
+        
+        // then
+        expect(bucketContents.files).to(haveCount(2))
+        expect(bucketContents.bucket).to(equal("TESTBUCKET1"))
+        expect(bucketContents.truncated).to(equal(true))
+        expect(bucketContents.maxKeys).to(equal(3))
+        
+        expect(s3File.name).to(equal("demo.txt"))
+        expect(s3File.modified).to(equal(expectedModifiedDate))
+        expect(s3File.size).to(equal(6))
+        expect(s3File.storageClass).to(equal(AmazonS3StorageClass.Standard))
+        expect(s3File.owner!.id).to(equal("61646d696e00000000"))
+        expect(s3File.owner!.name).to(equal("admin"))
+    }
+
+}

--- a/Example/Tests/AmazonS3ResponseObjectTests.swift
+++ b/Example/Tests/AmazonS3ResponseObjectTests.swift
@@ -14,6 +14,19 @@ import Alamofire
 
 class AmazonS3ResponseObjectTests: XCTestCase {
 
+    func test__responseS3Object_givenMetaData_returnsS3MetaDataResult() {
+        // given
+        let headers = ["x-amz-meta-test1" : "foo", "x-amz-meta-test2" : "bar"]
+        let response = NSHTTPURLResponse(URL: NSURL(), statusCode: 200, HTTPVersion: nil, headerFields: headers)
+        
+        // when
+        let metaDataResult = S3MetaDataResult(response:response!, representation:"")!
+        
+        // then
+        expect(metaDataResult.metaData["test1"]).to(equal("foo"))
+        expect(metaDataResult.metaData["test2"]).to(equal("bar"))
+    }
+    
     func test__responseS3Object_givenXMLString_returnsS3ListBucketResult() {
         // given
         let dateFormatter = NSDateFormatter()

--- a/Example/Tests/AmazonS3ResponseObjectTests.swift
+++ b/Example/Tests/AmazonS3ResponseObjectTests.swift
@@ -79,7 +79,7 @@ class AmazonS3ResponseObjectTests: XCTestCase {
         expect(bucketContents.truncated).to(equal(true))
         expect(bucketContents.maxKeys).to(equal(3))
         
-        expect(s3File.name).to(equal("demo.txt"))
+        expect(s3File.path).to(equal("demo.txt"))
         expect(s3File.modified).to(equal(expectedModifiedDate))
         expect(s3File.size).to(equal(6))
         expect(s3File.storageClass).to(equal(AmazonS3StorageClass.Standard))

--- a/Example/Tests/AmazonS3ResponseSerializationTests.swift
+++ b/Example/Tests/AmazonS3ResponseSerializationTests.swift
@@ -91,5 +91,22 @@ class AmazonS3ResponseSerializationTests: XCTestCase {
     // then
     expect(result.error).to(equal(expectedError))
   }
+    
+  func test__XMLResponseSerializer__givenXMLString_returnsXMLIndexer() {
+    // given    
+    let xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+      "<XMLData>" +
+        "<XMLElement>test</XMLElement>" +
+      "</XMLData>"
+    let data = xml.dataUsingEncoding(NSUTF8StringEncoding)
+    
+    // when
+    let result = Request.XMLResponseSerializer().serializeResponse(nil, nil, data, nil)
+    let testContent = result.value!["XMLData"]["XMLElement"].element?.text
+    
+    // then
+    expect(result.error).to(beNil())
+    expect(testContent).to(equal("test"))
+  }
   
 }

--- a/Source/AmazonS3RequestManager.swift
+++ b/Source/AmazonS3RequestManager.swift
@@ -199,6 +199,14 @@ public class AmazonS3RequestManager {
     
     return requestManager.request(deleteRequest)
   }
+    
+  // MARK: LIST Bucket Request
+    
+  public func listBucket() -> Request {
+    let listRequest = requestSerializer.amazonURLRequest(.GET)
+        
+    return requestManager.request(listRequest)
+  }
   
   // MARK: ACL Requests
   

--- a/Source/AmazonS3RequestManager.swift
+++ b/Source/AmazonS3RequestManager.swift
@@ -207,6 +207,14 @@ public class AmazonS3RequestManager {
         
     return requestManager.request(listRequest)
   }
+    
+  // MARK: HEAD Object Request
+    
+  public func headObject(path:String) -> Request {
+    let headRequest = requestSerializer.amazonURLRequest(.HEAD, path: path)
+        
+    return requestManager.request(headRequest)
+  }
   
   // MARK: ACL Requests
   

--- a/Source/AmazonS3RequestManager.swift
+++ b/Source/AmazonS3RequestManager.swift
@@ -155,12 +155,13 @@ public class AmazonS3RequestManager {
   
   - parameter fileURL:         The local `NSURL` of the file to upload
   - parameter destinationPath: The desired destination path, including the file name and extension, in the Amazon S3 bucket
+  - parameter metaData:        An optional dictionary of meta data that should be assigned to the object to be uploaded.
   - parameter acl:             The optional access control list to set the acl headers for the request. For more information see `AmazonS3ACL`.
   
   - returns: An upload request for the object
   */
-  public func putObject(fileURL: NSURL, destinationPath: String, acl: AmazonS3ACL? = nil, storageClass: AmazonS3StorageClass = .Standard) -> Request {
-    let putRequest = requestSerializer.amazonURLRequest(.PUT, path: destinationPath, acl: acl, storageClass: storageClass)
+  public func putObject(fileURL: NSURL, destinationPath: String, metaData:[String : String] = [:], acl: AmazonS3ACL? = nil, storageClass: AmazonS3StorageClass = .Standard) -> Request {
+    let putRequest = requestSerializer.amazonURLRequest(.PUT, path: destinationPath, acl: acl, storageClass: storageClass, metaData: metaData)
     
     return requestManager.upload(putRequest, file: fileURL)
   }
@@ -172,13 +173,14 @@ public class AmazonS3RequestManager {
   
   - parameter data:            The `NSData` for the object to upload
   - parameter destinationPath: The desired destination path, including the file name and extension, in the Amazon S3 bucket
+  - parameter metaData:        An optional dictionary of meta data that should be assigned to the object to be uploaded.
   - parameter acl:             The optional access control list to set the acl headers for the request. For more information see `AmazonS3ACL`.
   - parameter storageClass:    The optional storage class to use for the object to upload. If none is specified, standard is used. For more information see `AmazonS3StorageClass`.
   
   - returns: An upload request for the object
   */
-  public func putObject(data: NSData, destinationPath: String, acl: AmazonS3ACL? = nil, storageClass: AmazonS3StorageClass = .Standard) -> Request {
-    let putRequest = requestSerializer.amazonURLRequest(.PUT, path: destinationPath, acl: acl, storageClass: storageClass)
+  public func putObject(data: NSData, destinationPath: String, metaData:[String : String] = [:], acl: AmazonS3ACL? = nil, storageClass: AmazonS3StorageClass = .Standard) -> Request {
+    let putRequest = requestSerializer.amazonURLRequest(.PUT, path: destinationPath, acl: acl, storageClass: storageClass, metaData: metaData)
     
     return requestManager.upload(putRequest, data: data)
   }

--- a/Source/AmazonS3RequestSerializer.swift
+++ b/Source/AmazonS3RequestSerializer.swift
@@ -99,7 +99,8 @@ public class AmazonS3RequestSerializer {
         path: String? = nil,
         subresource: String? = nil,
         acl: AmazonS3ACL? = nil,
-        storageClass: AmazonS3StorageClass = .Standard) -> NSURLRequest {
+        storageClass: AmazonS3StorageClass = .Standard,
+        metaData:[String : String] = [:]) -> NSURLRequest {
             let url = requestURL(path, subresource: subresource)
             
             var mutableURLRequest = NSMutableURLRequest(URL: url)
@@ -109,6 +110,8 @@ public class AmazonS3RequestSerializer {
             acl?.setACLHeaders(forRequest: &mutableURLRequest)
             
             setStorageClassHeaders(forRequest: &mutableURLRequest, storageClass: storageClass)
+            
+            setMetaDataHeaders(metaData, forRequest: &mutableURLRequest)
             
             setAuthorizationHeaders(forRequest: &mutableURLRequest)
             
@@ -187,6 +190,12 @@ public class AmazonS3RequestSerializer {
     
     private func setStorageClassHeaders(inout forRequest request: NSMutableURLRequest, storageClass: AmazonS3StorageClass) {
         request.setValue(storageClass.rawValue, forHTTPHeaderField: "x-amz-storage-class")
+    }
+    
+    private func setMetaDataHeaders(metaData:[String : String], inout forRequest request: NSMutableURLRequest) {
+        for (key, value) in metaData {
+            request.setValue(value, forHTTPHeaderField: "x-amz-meta-" + key)
+        }
     }
     
     private func currentTimeStamp() -> String {

--- a/Source/AmazonS3ResponseObjects.swift
+++ b/Source/AmazonS3ResponseObjects.swift
@@ -20,7 +20,7 @@ public protocol ResponseObjectSerializable {
  Struct for holding attributes of a file representation returned by an S3 instance.
  */
 public struct S3File {
-    public let name: String
+    public let path: String
     public let modified: NSDate
     public let size:Int
     public let storageClass:AmazonS3StorageClass?
@@ -64,7 +64,7 @@ public final class S3ListBucketResult: ResponseObjectSerializable {
         for element in xml {
             
             let file = S3File(
-                name: (element["Key"].element?.text)!,
+                path: (element["Key"].element?.text)!,
                 modified: dateFromS3Date((element["LastModified"].element?.text)!)!,
                 size: Int((element["Size"].element?.text)!)!,
                 storageClass: AmazonS3StorageClass(rawValue: (element["StorageClass"].element?.text)!),

--- a/Source/AmazonS3ResponseObjects.swift
+++ b/Source/AmazonS3ResponseObjects.swift
@@ -1,0 +1,77 @@
+//
+//  AmazonS3ResponseObjects.swift
+//  AmazonS3RequestManager
+//
+//  Created by Sebastian Hunkeler on 17/03/16.
+//
+//
+
+import Foundation
+import SWXMLHash
+
+/**
+ Protocol for serializable object classes.
+ */
+public protocol ResponseObjectSerializable {
+    init?(response: NSHTTPURLResponse, representation: Any)
+}
+
+/**
+ Struct for holding attributes of a file representation returned by an S3 instance.
+ */
+public struct S3File {
+    public let name: String
+    public let modified: NSDate
+    public let size:Int
+    public let storageClass:AmazonS3StorageClass?
+    public let owner:(id:String,name:String)?
+}
+
+/**
+ Class for representing the result data of a LIST operation on an S3 instance.
+ */
+public final class S3ListBucketResult: ResponseObjectSerializable {
+    public var files:[S3File] = []
+    public var bucket:String?
+    public var truncated:Bool?
+    public var maxKeys:Int?
+    
+    public init?(response: NSHTTPURLResponse, representation: Any) {
+        guard let xml = representation as? XMLIndexer else { return nil }
+        
+        bucket = xml["ListBucketResult"]["Name"].element?.text
+        
+        if let isTruncated = xml["ListBucketResult"]["IsTruncated"].element?.text {
+            truncated = Bool(isTruncated == "true")
+        }
+        
+        if let maximumKeys = xml["ListBucketResult"]["MaxKeys"].element?.text {
+            maxKeys = Int(maximumKeys)
+        }
+        
+        parseContents(xml["ListBucketResult"]["Contents"])
+    }
+    
+    private func dateFromS3Date(rawDate:String) -> NSDate? {
+        let dateFormatter = NSDateFormatter()
+        dateFormatter.locale = NSLocale(localeIdentifier: "en_US_POSIX")
+        dateFormatter.timeZone = NSTimeZone.localTimeZone()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+        return dateFormatter.dateFromString(rawDate)
+    }
+    
+    private func parseContents(xml:XMLIndexer) {
+        for element in xml {
+            
+            let file = S3File(
+                name: (element["Key"].element?.text)!,
+                modified: dateFromS3Date((element["LastModified"].element?.text)!)!,
+                size: Int((element["Size"].element?.text)!)!,
+                storageClass: AmazonS3StorageClass(rawValue: (element["StorageClass"].element?.text)!),
+                owner: ((element["Owner"]["ID"].element?.text)!,(element["Owner"]["DisplayName"].element?.text)!)
+            )
+            files.append(file)
+        }
+    }
+    
+}

--- a/Source/AmazonS3ResponseObjects.swift
+++ b/Source/AmazonS3ResponseObjects.swift
@@ -75,3 +75,25 @@ public final class S3ListBucketResult: ResponseObjectSerializable {
     }
     
 }
+
+/**
+Class for representing the result data of a HEAD operation on an S3 instance.
+*/
+public final class S3MetaDataResult: ResponseObjectSerializable {
+    public var metaData: [String : String] = [:]
+    
+    public init?(response: NSHTTPURLResponse, representation: Any) {
+        if let headers = response.allHeaderFields as? [String : String] {
+            
+            for (header,value) in headers {
+                let prefix = "x-amz-meta-"
+                if header.hasPrefix(prefix) {
+                    let trimmedHeaderName = header.substringFromIndex(prefix.startIndex.advancedBy(prefix.characters.count))
+                    metaData[trimmedHeaderName] = value
+                }
+            }
+            
+        }
+    }
+    
+}

--- a/Source/AmazonS3ResponseSerialization.swift
+++ b/Source/AmazonS3ResponseSerialization.swift
@@ -14,6 +14,25 @@ import SWXMLHash
 extension Request {
   
   /**
+   Creates a response serializer that parses XML data and returns an XML indexer.
+   
+   - returns: A XML indexer
+   */
+  public static func XMLResponseSerializer() -> ResponseSerializer<XMLIndexer, NSError> {
+    return ResponseSerializer { request, response, data, error in
+      guard error == nil else { return .Failure(error!) }
+      
+      guard let validData = data else {
+        let failureReason = "Data could not be serialized. Input data was nil."
+        let error = Error.errorWithCode(.DataSerializationFailed, failureReason: failureReason)
+        return .Failure(error)
+      }
+      let xml = SWXMLHash.parse(validData)
+      return .Success(xml)
+    }
+  }
+    
+  /**
   Creates a response serializer that parses any errors from the Amazon S3 Service and returns the associated data.
   
   - returns: A data response serializer


### PR DESCRIPTION
This PR implements the functionality to read and write user defined object meta data.
Example usage:

```
let metaData = ["finalized" : "yes"]
amazonS3Manager.putObject(fileURL, destinationPath: fileURL.lastPathComponent!,metaData: metaData).response { 
    request, response, data, error in
    print(request)
    print(response)
    print(error)
}

amazonS3Manager.headObject(fileURL.lastPathComponent!).responseS3Object { 
    (response: Response<S3MetaDataResult, NSError>) in
    if let metaData = response.result.value?.metaData {
        for objectMetaData in metaData {
            print(objectMetaData)
        }
    }
}
```
