### PR TITLE
Allow for copying files - Implements #26

### DIFF
--- a/Example/Tests/AmazonS3RequestManagerTests.swift
+++ b/Example/Tests/AmazonS3RequestManagerTests.swift
@@ -137,7 +137,7 @@ class AmazonS3RequestManagerTests: XCTestCase {
         let expectedURL = NSURL(string: "https://\(region.endpoint)/\(bucket)?list-type=2&max-keys=100&prefix=TestPath")!
         
         // when
-        let request = sut.listBucketObjects(maxKeys: "100", prefix: "TestPath")
+        let request = sut.listBucketObjects(maxKeys: 100, prefix: "TestPath")
         
         // then
         XCTAssertEqual(request.request!.URL!, expectedURL)

--- a/Example/Tests/AmazonS3RequestManagerTests.swift
+++ b/Example/Tests/AmazonS3RequestManagerTests.swift
@@ -123,10 +123,21 @@ class AmazonS3RequestManagerTests: XCTestCase {
     
     func test__listBucketObjects__setsURL() {
         // given
-        let expectedURL = NSURL(string: "https://\(region.endpoint)/\(bucket)")!
+        let expectedURL = NSURL(string: "https://\(region.endpoint)/\(bucket)?list-type=2")!
         
         // when
         let request = sut.listBucketObjects()
+        
+        // then
+        XCTAssertEqual(request.request!.URL!, expectedURL)
+    }
+    
+    func test__listBucketObjectsWithCustomParameters__setsURL() {
+        // given
+        let expectedURL = NSURL(string: "https://\(region.endpoint)/\(bucket)?list-type=2&max-keys=100&prefix=TestPath")!
+        
+        // when
+        let request = sut.listBucketObjects(maxKeys: "100", prefix: "TestPath")
         
         // then
         XCTAssertEqual(request.request!.URL!, expectedURL)

--- a/Example/Tests/AmazonS3RequestManagerTests.swift
+++ b/Example/Tests/AmazonS3RequestManagerTests.swift
@@ -239,8 +239,51 @@ class AmazonS3RequestManagerTests: XCTestCase {
         XCTAssertNotNil(aclHeader, "Should have ACL header field")
     }
     
+     /*
+     *  MARK: - COPY Object Request - Tests
+     */
+    
+    func test__copyObject_setsHTTPMethod() {
+        // given
+        let expected = "PUT"
+        
+        // when
+        let request = sut.copyObject("test", destinationPath: "demo")
+        
+        // then
+        XCTAssertEqual(request.request!.HTTPMethod!, expected)
+    }
+    
+    func test__copyObject_givenDestinationPath_setsHTTPHeader_amz_copy() {
+        // given
+        let sourcePath = "TestSourcePath"
+        let targetPath = "TestTargetPath"
+        let expectedCompleteSourcePath = "/" + bucket + "/" + sourcePath
+        
+        let request = sut.copyObject(sourcePath, destinationPath: targetPath)
+        
+        // when
+        let headers = request.request!.allHTTPHeaderFields!
+        let copyHeader: String = headers["x-amz-copy-source"]!
+        
+        // then
+        XCTAssertEqual(copyHeader, expectedCompleteSourcePath, "AMZ copy header is not set correctly")
+    }
+    
+    func test__copyObject_fileURL_destinationPath_setsURLWithEndpoint() {
+        // given
+        let path = "TestPath"
+        let expectedURL = NSURL(string: "https://\(region.endpoint)/\(bucket)/TestPath")!
+        
+        // when
+        let request = sut.copyObject("sourcePath", destinationPath: path)
+        
+        // then
+        XCTAssertEqual(request.request!.URL!, expectedURL)
+    }
+    
     /*
-    *  MARK: DELETE Object Request - Tests
+    *  MARK: - DELETE Object Request - Tests
     */
     
     func test__deleteObject_setsHTTPMethod() {

--- a/Example/Tests/AmazonS3RequestSerializerTests.swift
+++ b/Example/Tests/AmazonS3RequestSerializerTests.swift
@@ -246,10 +246,25 @@ class AmazonS3RequestSerializerTests: XCTestCase {
     let expectedEndpoint = "test.endpoint.com"
     let region = AmazonS3Region.Custom(hostName: "", endpoint: expectedEndpoint)
     sut.region = region
-    let expectedURL = NSURL(string: "https://\(expectedEndpoint)/\(bucket)/\(path)?custom-param=custom%20value!/")!
+    let expectedURL = NSURL(string: "https://\(expectedEndpoint)/\(bucket)/\(path)?custom-param=custom%20value%21%2F")!
     
     // when
     let request = sut.amazonURLRequest(.GET, path: path, customParameters: ["custom-param" : "custom value!/"])
+    
+    // then
+    XCTAssertEqual(request.URL!, expectedURL)
+  }
+  
+  func test__amazonURLRequest__givenCustomParameters_setsURLWithEndpointURL_ContinuationToken() {
+    // given
+    let path = "TestPath"
+    let expectedEndpoint = "test.endpoint.com"
+    let region = AmazonS3Region.Custom(hostName: "", endpoint: expectedEndpoint)
+    sut.region = region
+    let expectedURL = NSURL(string: "https://\(expectedEndpoint)/\(bucket)/\(path)?continuation-token=1%2FkCRyYIP%2BApo2oop%2FGa8%2FnVMR6hC7pDH%2FlL6JJrSZ3blAYaZkzJY%2FRVMcJ")!
+    
+    // when
+    let request = sut.amazonURLRequest(.GET, path: path, customParameters: ["continuation-token" : "1/kCRyYIP+Apo2oop/Ga8/nVMR6hC7pDH/lL6JJrSZ3blAYaZkzJY/RVMcJ"])
     
     // then
     XCTAssertEqual(request.URL!, expectedURL)

--- a/Example/Tests/AmazonS3RequestSerializerTests.swift
+++ b/Example/Tests/AmazonS3RequestSerializerTests.swift
@@ -240,4 +240,19 @@ class AmazonS3RequestSerializerTests: XCTestCase {
     XCTAssertEqual(metaDataHeader, "foo", "Meta data header field is not set correctly.")
   }
   
+  func test__amazonURLRequest__givenCustomParameters_setsURLWithEndpointURL() {
+    // given
+    let path = "TestPath"
+    let expectedEndpoint = "test.endpoint.com"
+    let region = AmazonS3Region.Custom(hostName: "", endpoint: expectedEndpoint)
+    sut.region = region
+    let expectedURL = NSURL(string: "https://\(expectedEndpoint)/\(bucket)/\(path)?custom-param=custom%20value!/")!
+    
+    // when
+    let request = sut.amazonURLRequest(.GET, path: path, customParameters: ["custom-param" : "custom value!/"])
+    
+    // then
+    XCTAssertEqual(request.URL!, expectedURL)
+  }
+  
 }

--- a/Example/Tests/AmazonS3RequestSerializerTests.swift
+++ b/Example/Tests/AmazonS3RequestSerializerTests.swift
@@ -270,4 +270,20 @@ class AmazonS3RequestSerializerTests: XCTestCase {
     XCTAssertEqual(request.URL!, expectedURL)
   }
   
+  func test_amazonURLRequest__givenCustomHeaders() {
+    // given
+    let headers = ["header-demo" : "foo", "header-test" : "bar"]
+    let request = sut.amazonURLRequest(.HEAD, path: "test", customHeaders: headers)
+    
+    // when
+    let httpHeaders = request.allHTTPHeaderFields!
+    let header1: String? = httpHeaders["header-demo"]
+    let header2: String? = httpHeaders["header-test"]
+    
+    // then
+    XCTAssertEqual(header1, "foo", "Meta data header field is not set correctly.")
+    XCTAssertEqual(header2, "bar", "Meta data header field is not set correctly.")
+  }
+
+  
 }

--- a/README.md
+++ b/README.md
@@ -99,6 +99,14 @@ amazonS3Manager.headObject("fileName.txt").responseS3MetaData { (response: Respo
 let fileURL: NSURL = NSURL(fileURLWithPath: "pathToMyObject")
 amazonS3Manager.putObject(fileURL, destinationPath: "pathToSaveObjectTo/fileName.jpg")
 ```
+
+### Copy Objects
+```swift
+amazonS3Manager.copyObject("demo.txt", destinationPath: "copy.txt").response { request, response, data, error in    
+    print(response)    
+    print(error)
+}
+```
     
 ### Delete Objects
 ```swift

--- a/README.md
+++ b/README.md
@@ -53,6 +53,19 @@ let amazonS3Manager = AmazonS3RequestManager(bucket: myAmazonS3Bucket,
     secret: myAmazonS3Secret)
 ```
 
+### List Bucket Objects
+Gets a list of object in a bucket:
+
+```swift
+amazonS3Manager.listBucketObjects().responseS3Object { (response: Response<S3BucketObjectList, NSError>) in
+    if let files = response.result.value?.files {
+        for file in files {
+            print(file.path)
+        }
+    }
+}
+```
+
 ### Get Objects
 
 Getting Objects as Response Objects:
@@ -68,6 +81,19 @@ let destination: NSURL = NSFileManager.defaultManager().URLsForDirectory(.Docume
 amazonS3Manager.downloadObject("myFolder/fileName.jpg", saveToURL: destination)
 ```
     
+### Head Objects
+Retrieve metadata from an object without returning the object itself:
+
+```swift
+amazonS3Manager.headObject("fileName.txt").responseS3MetaData { (response: Response<S3ObjectMetaData, NSError>) in
+    if let metaData = response.result.value?.metaData {
+        for objectMetaData in metaData {
+            print(objectMetaData)
+        }
+    }
+}
+```
+
 ### Upload Objects
 ```swift
 let fileURL: NSURL = NSURL(fileURLWithPath: "pathToMyObject")

--- a/Source/AmazonS3RequestManager.swift
+++ b/Source/AmazonS3RequestManager.swift
@@ -286,7 +286,7 @@ public class AmazonS3RequestManager {
     - note: This request returns meta data about the objects in the bucket. It does not return all of the bucket's object data.
     
     - parameter delimiter: A delimiter is a character you use to group keys.
-    - parameter encodingType: Requests Amazon S3 to encode the response and specifies the encoding method to use.
+    - parameter urlEncodeKeys: Requests Amazon S3 to URL encode the response.
     - parameter maxKeys: Sets the maximum number of keys returned in the response body. If you want to retrieve fewer than the default 1,000 keys, you can add this to your request.
     - parameter prefix: Limits the response to keys that begin with the specified prefix. You can use prefixes to separate a bucket into different groupings of keys. (You can think of using prefix to make groups in the same way you'd use a folder in a file system.)
     - parameter continuationToken: When the Amazon S3 response to this API call is truncated (that is, IsTruncated response element value is true), the response also includes the NextContinuationToken element, the value of which you can use in the next request as the continuation-token to list the next set of objects.
@@ -296,11 +296,11 @@ public class AmazonS3RequestManager {
     - returns: The get bucket object list request
     */
     public func listBucketObjects(delimiter: String? = nil,
-                                    encodingType: String? = nil,
-                                    maxKeys: String? = nil,
+                                    urlEncodeKeys: Bool? = nil,
+                                    maxKeys: UInt? = nil,
                                     prefix: String? = nil,
                                     continuationToken: String? = nil,
-                                    fetchOwner: String? = nil,
+                                    fetchOwner: Bool? = nil,
                                     startAfter: String? = nil) -> Request {
         
         var requestParameters: [String : String] = [:]
@@ -312,12 +312,12 @@ public class AmazonS3RequestManager {
             requestParameters["delimiter"] = delimiter
         }
         
-        if let encodingType = encodingType {
-            requestParameters["encoding-type"] = encodingType
+        if let urlEncodeKeys = urlEncodeKeys {
+            requestParameters["encoding-type"] = urlEncodeKeys ? "url" : ""
         }
         
         if let maxKeys = maxKeys {
-            requestParameters["max-keys"] = maxKeys
+            requestParameters["max-keys"] = "\(maxKeys)"
         }
         
         if let prefix = prefix {
@@ -329,7 +329,7 @@ public class AmazonS3RequestManager {
         }
         
         if let fetchOwner = fetchOwner {
-            requestParameters["fetch-owner"] = fetchOwner
+            requestParameters["fetch-owner"] = fetchOwner ? "true" : "false"
         }
         
         if let startAfter = startAfter {

--- a/Source/AmazonS3RequestManager.swift
+++ b/Source/AmazonS3RequestManager.swift
@@ -285,10 +285,58 @@ public class AmazonS3RequestManager {
     
     - note: This request returns meta data about the objects in the bucket. It does not return all of the bucket's object data.
     
+    - parameter delimiter: A delimiter is a character you use to group keys.
+    - parameter encodingType: Requests Amazon S3 to encode the response and specifies the encoding method to use.
+    - parameter maxKeys: Sets the maximum number of keys returned in the response body. If you want to retrieve fewer than the default 1,000 keys, you can add this to your request.
+    - parameter prefix: Limits the response to keys that begin with the specified prefix. You can use prefixes to separate a bucket into different groupings of keys. (You can think of using prefix to make groups in the same way you'd use a folder in a file system.)
+    - parameter continuationToken: When the Amazon S3 response to this API call is truncated (that is, IsTruncated response element value is true), the response also includes the NextContinuationToken element, the value of which you can use in the next request as the continuation-token to list the next set of objects.
+    - parameter fetchOwner: By default, the API does not return the Owner information in the response. If you want the owner information in the response, you can specify this parameter with the value set to true.
+    - parameter startAfter: If you want the API to return key names after a specific object key in your key space, you can add this parameter. Amazon S3 lists objects in UTF-8 character encoding in lexicographical order.
+     
     - returns: The get bucket object list request
     */
-    public func listBucketObjects() -> Request {
-        let listRequest = requestSerializer.amazonURLRequest(.GET)
+    public func listBucketObjects(delimiter: String? = nil,
+                                    encodingType: String? = nil,
+                                    maxKeys: String? = nil,
+                                    prefix: String? = nil,
+                                    continuationToken: String? = nil,
+                                    fetchOwner: String? = nil,
+                                    startAfter: String? = nil) -> Request {
+        
+        var requestParameters: [String : String] = [:]
+        
+        //Version 2 of the API requires this parameter and you must set its value to 2.
+        requestParameters["list-type"] = "2"
+        
+        if let delimiter = delimiter {
+            requestParameters["delimiter"] = delimiter
+        }
+        
+        if let encodingType = encodingType {
+            requestParameters["encoding-type"] = encodingType
+        }
+        
+        if let maxKeys = maxKeys {
+            requestParameters["max-keys"] = maxKeys
+        }
+        
+        if let prefix = prefix {
+            requestParameters["prefix"] = prefix
+        }
+        
+        if let continuationToken = continuationToken {
+            requestParameters["continuation-token"] = continuationToken
+        }
+        
+        if let fetchOwner = fetchOwner {
+            requestParameters["fetch-owner"] = fetchOwner
+        }
+        
+        if let startAfter = startAfter {
+            requestParameters["start-after"] = startAfter
+        }
+        
+        let listRequest = requestSerializer.amazonURLRequest(.GET, path: nil, subresource: nil, customParameters: requestParameters)
         
         return requestManager.request(listRequest)
     }

--- a/Source/AmazonS3RequestManager.swift
+++ b/Source/AmazonS3RequestManager.swift
@@ -261,6 +261,30 @@ public class AmazonS3RequestManager {
         return requestManager.request(headRequest)
     }
     
+    // MARK: COPY Object Request
+    
+    /**
+     Copies an object to a target destination while preserving the object's meta data.
+     
+     - parameter sourcePath: The object's source path
+     - parameter destinationPath: The object's target destination path on the bucket.
+     
+     - returns: The put request
+     */
+    public func copyObject(sourcePath: String, destinationPath: String) -> Request {
+        
+        var completeSourcePath = "/"
+        
+        if let bucket = requestSerializer.bucket {
+            completeSourcePath += bucket
+            completeSourcePath += (sourcePath.hasPrefix("/") ? "" : "/") + sourcePath
+        }
+        
+        let putRequest = requestSerializer.amazonURLRequest(.PUT, path: destinationPath, customHeaders: ["x-amz-copy-source" : completeSourcePath])
+        
+        return requestManager.request(putRequest)
+    }
+    
     // MARK: DELETE Object Request
     
     /**

--- a/Source/AmazonS3RequestSerializer.swift
+++ b/Source/AmazonS3RequestSerializer.swift
@@ -242,10 +242,9 @@ private extension NSURL {
             return self
         }
         
+        guard let encodedValue = value.stringByAddingPercentEncodingWithAllowedCharacters(.alphanumericCharacterSet()) else { return NSURL() }
         var URLString = self.absoluteString
-        let parameter:NSString = key + "=" + value
-        guard let encodedParameter = parameter.stringByAddingPercentEncodingWithAllowedCharacters(.URLQueryAllowedCharacterSet()) else { return NSURL() }
-        URLString = URLString + (URLString.rangeOfString("?") == nil ? "?" : "&") + encodedParameter
+        URLString = URLString + (URLString.rangeOfString("?") == nil ? "?" : "&") + key + "=" + encodedValue
         
         return NSURL(string: URLString)!
     }

--- a/Source/AmazonS3RequestSerializer.swift
+++ b/Source/AmazonS3RequestSerializer.swift
@@ -106,8 +106,9 @@ public class AmazonS3RequestSerializer {
         subresource: String? = nil,
         acl: AmazonS3ACL? = nil,
         metaData:[String : String]? = nil,
-        storageClass: AmazonS3StorageClass = .Standard) -> NSURLRequest {
-            let url = requestURL(path, subresource: subresource)
+        storageClass: AmazonS3StorageClass = .Standard,
+        customParameters:[String : String]? = nil) -> NSURLRequest {
+            let url = requestURL(path, subresource: subresource, customParameters: customParameters)
             
             var mutableURLRequest = NSMutableURLRequest(URL: url)
             mutableURLRequest.HTTPMethod = method.rawValue
@@ -121,7 +122,7 @@ public class AmazonS3RequestSerializer {
             return mutableURLRequest
     }
     
-    private func requestURL(path: String?, subresource: String?) -> NSURL {
+    private func requestURL(path: String?, subresource: String?, customParameters:[String : String]? = nil) -> NSURL {
         var url = endpointURL
         if let path = path {
             url = url.URLByAppendingPathComponent(path)
@@ -130,6 +131,13 @@ public class AmazonS3RequestSerializer {
         if let subresource = subresource {
             url = url.URLByAppendingS3Subresource(subresource)
         }
+        
+        if let customParameters = customParameters {
+            for (key, value) in customParameters {
+                url = url.URLByAppendingRequestParameter(key, value: value)
+            }
+        }
+        
         return url
     }
     
@@ -226,6 +234,20 @@ private extension NSURL {
             
         }
         return self
+    }
+    
+    private func URLByAppendingRequestParameter(key: String, value: String) -> NSURL {
+        
+        if key.isEmpty || value.isEmpty {
+            return self
+        }
+        
+        var URLString = self.absoluteString
+        let parameter:NSString = key + "=" + value
+        guard let encodedParameter = parameter.stringByAddingPercentEncodingWithAllowedCharacters(.URLQueryAllowedCharacterSet()) else { return NSURL() }
+        URLString = URLString + (URLString.rangeOfString("?") == nil ? "?" : "&") + encodedParameter
+        
+        return NSURL(string: URLString)!
     }
     
 }

--- a/Source/AmazonS3RequestSerializer.swift
+++ b/Source/AmazonS3RequestSerializer.swift
@@ -107,7 +107,8 @@ public class AmazonS3RequestSerializer {
         acl: AmazonS3ACL? = nil,
         metaData:[String : String]? = nil,
         storageClass: AmazonS3StorageClass = .Standard,
-        customParameters:[String : String]? = nil) -> NSURLRequest {
+        customParameters:[String : String]? = nil,
+        customHeaders:[String : String]? = nil) -> NSURLRequest {
             let url = requestURL(path, subresource: subresource, customParameters: customParameters)
             
             var mutableURLRequest = NSMutableURLRequest(URL: url)
@@ -117,6 +118,7 @@ public class AmazonS3RequestSerializer {
             acl?.setACLHeaders(forRequest: &mutableURLRequest)
             setStorageClassHeaders(storageClass, forRequest: &mutableURLRequest)
             setMetaDataHeaders(metaData, forRequest: &mutableURLRequest)
+            setCustomHeaders(customHeaders, forRequest: &mutableURLRequest)
             setAuthorizationHeaders(forRequest: &mutableURLRequest)
             
             return mutableURLRequest
@@ -206,8 +208,20 @@ public class AmazonS3RequestSerializer {
     private func setMetaDataHeaders(metaData:[String : String]?, inout forRequest request: NSMutableURLRequest) {
         guard let metaData = metaData else { return }
         
+        var metadataHeaders:[String:String] = [:]
+        
         for (key, value) in metaData {
-            request.setValue(value, forHTTPHeaderField: "x-amz-meta-" + key)
+            metadataHeaders["x-amz-meta-" + key] = value
+        }
+        
+        setCustomHeaders(metadataHeaders, forRequest: &request)
+    }
+    
+    private func setCustomHeaders(headerFields:[String : String]?, inout forRequest request: NSMutableURLRequest) {
+        guard let headerFields = headerFields else { return }
+        
+        for (key, value) in headerFields {
+            request.setValue(value, forHTTPHeaderField: key)
         }
     }
     


### PR DESCRIPTION
This PR implements the functionality to copy files.
Example usage:

```
amazonS3Manager.copyObject("demo.txt", destinationPath: "copy.txt").response { request, response, data, error in
    print(request)
    print(response)
    print(data)
    print(error)
}
```
