### PR TITLE
Updated list operation to support 1000+ objects.

### DIFF
--- a/Source/AmazonS3RequestManager.swift
+++ b/Source/AmazonS3RequestManager.swift
@@ -281,14 +281,17 @@ public class AmazonS3RequestManager {
     // MARK: GET Bucket Objects List Request
     
     /**
-    Gets a list of object in a bucket. Returns up to 1000 objects.
+    Gets a list of objects in a bucket. Use continue token if you have more than 1000 objects.
     
     - note: This request returns meta data about the objects in the bucket. It does not return all of the bucket's object data.
     
     - returns: The get bucket object list request
     */
-    public func listBucketObjects() -> Request {
-        let listRequest = requestSerializer.amazonURLRequest(.GET)
+    public func listBucketObjects(continueToken: String? = nil) -> Request {
+        
+        let listBucketCall = "list-type=2"
+        let subResource = (continueToken == nil) ? listBucketCall : "\(listBucketCall)&continuation-token=\(continueToken!)"
+        let listRequest = requestSerializer.amazonURLRequest(.GET, subresource: subResource)
         
         return requestManager.request(listRequest)
     }

--- a/Source/AmazonS3RequestManager.swift
+++ b/Source/AmazonS3RequestManager.swift
@@ -284,13 +284,19 @@ public class AmazonS3RequestManager {
     Gets a list of objects in a bucket. Use continue token if you have more than 1000 objects.
     
     - note: This request returns meta data about the objects in the bucket. It does not return all of the bucket's object data.
+    - note: Continuation token sometimes include + characters, which doesn't pass and returns a mismatch error.
+    - note: Must encode the token with alphanumericCharacterSet instead of URLQueryAllowedCharacterSet.
     
     - returns: The get bucket object list request
     */
     public func listBucketObjects(continueToken: String? = nil) -> Request {
+        var subResource = "list-type=2"
         
-        let listBucketCall = "list-type=2"
-        let subResource = (continueToken == nil) ? listBucketCall : "\(listBucketCall)&continuation-token=\(continueToken!)"
+        if continueToken != nil {
+            let token = continueToken!.stringByAddingPercentEncodingWithAllowedCharacters(NSCharacterSet.alphanumericCharacterSet())!
+            subResource = subResource.stringByAppendingString("&continuation-token=\(token)")
+        }
+        
         let listRequest = requestSerializer.amazonURLRequest(.GET, subresource: subResource)
         
         return requestManager.request(listRequest)

--- a/Source/AmazonS3ResponseObjects.swift
+++ b/Source/AmazonS3ResponseObjects.swift
@@ -52,12 +52,16 @@ public final class S3BucketObjectList: ResponseObjectSerializable {
     public var bucket: String?
     public var truncated: Bool?
     public var maxKeys: Int?
+    public var continuationToken: String?
     
     public init?(response: NSHTTPURLResponse, representation xml: XMLIndexer) {
         bucket = xml["ListBucketResult"]["Name"].element?.text
         
         if let isTruncated = xml["ListBucketResult"]["IsTruncated"].element?.text {
             truncated = Bool(isTruncated == "true")
+            if let continueToken = xml["ListBucketResult"]["NextContinuationToken"].element?.text {
+                continuationToken = continueToken
+            }
         }
         
         if let maximumKeys = xml["ListBucketResult"]["MaxKeys"].element?.text {


### PR DESCRIPTION
Amazon now recommends using GET Bucket (List Objects) Version 2.
Continuation token can now be used to retrieve the next set of objects past 1000. 
