### PR TITLE
Use integral values for file sizes

### DIFF
--- a/Source/ResponseObjects.swift
+++ b/Source/ResponseObjects.swift
@@ -82,8 +82,6 @@ public final class S3BucketObjectList: ResponseObjectSerializable {
             let sizeString = xml["Size"].element?.text,
             let size = Int64(sizeString) else { return nil }
 
-		print("sizeString='\(sizeString)' size=\(size) path=\(path)")
-
         var storageClass: StorageClass?
         if let storageClassString = xml["StorageClass"].element?.text {
             storageClass = StorageClass(rawValue: storageClassString)

--- a/Source/ResponseObjects.swift
+++ b/Source/ResponseObjects.swift
@@ -32,7 +32,7 @@ public struct S3File {
     public let lastModifiedDate: Date
     
     /// The size in bytes of the object
-    public let size: Float
+    public let size: Int64
     
     /// An MD5 hash of the object. This only reflects changes to the contents of an object, not its metadata.
     public let entityTag: String?
@@ -80,7 +80,9 @@ public final class S3BucketObjectList: ResponseObjectSerializable {
             let dateString = xml["LastModified"].element?.text,
             let date =  dateFromS3Date(dateString),
             let sizeString = xml["Size"].element?.text,
-            let size = Float(sizeString) else { return nil }
+            let size = Int64(sizeString) else { return nil }
+
+		print("sizeString='\(sizeString)' size=\(size) path=\(path)")
 
         var storageClass: StorageClass?
         if let storageClassString = xml["StorageClass"].element?.text {


### PR DESCRIPTION
Float conversions were producing errors. In several cases, converting the byte size from text to float produced a value that was off-by-one.

